### PR TITLE
Add customer and employer management pages

### DIFF
--- a/add-customer.html
+++ b/add-customer.html
@@ -233,9 +233,15 @@
                     </div>
                     <div class="form-row">
                         <div class="form-group">
-                            <label class="form-label">Employer Name</label>
-                            <input type="text" class="form-input" name="employerName" placeholder="Enter employer name">
+                            <label class="form-label">Employer <span class="required">*</span></label>
+                            <input type="text" class="form-input" id="employerName" name="employerName" placeholder="Enter employer name" required>
                         </div>
+                        <div class="form-group">
+                            <label class="form-label">Employer Code</label>
+                            <input type="text" class="form-input" id="employerCode" name="employerCode" readonly>
+                        </div>
+                    </div>
+                    <div class="form-row">
                         <div class="form-group">
                             <label class="form-label">Job Title</label>
                             <input type="text" class="form-input" name="jobTitle" placeholder="Enter job title">
@@ -347,20 +353,55 @@
             document.getElementById('formActions').style.display=currentStep===4?'none':'flex';
         }
         const form=document.getElementById('customerForm');
+        const employerNameInput=document.getElementById('employerName');
+        const employerCodeInput=document.getElementById('employerCode');
+
+        function generateCode(name){
+            const prefix=name.trim().slice(0,3).toUpperCase();
+            return prefix+Date.now().toString().slice(-4);
+        }
+
+        employerNameInput.addEventListener('input',()=>{
+            employerCodeInput.value = employerNameInput.value ? generateCode(employerNameInput.value) : '';
+        });
+
+        const urlParams=new URLSearchParams(window.location.search);
+        const editId=urlParams.get('id');
+        if(editId){
+            const customers=JSON.parse(localStorage.getItem('customers'))||[];
+            const customer=customers.find(c=>c.id==editId);
+            if(customer){
+                Object.keys(customer).forEach(k=>{if(form.elements[k]) form.elements[k].value=customer[k];});
+            }
+        }
+
         form.addEventListener('submit',function(e){
             e.preventDefault();
             if(validateCurrentStep()){
                 const data={};
                 new FormData(form).forEach((v,k)=>data[k]=v);
-                data.id = Date.now();
-                localStorage.setItem('recentCustomer', JSON.stringify(data));
                 const customers = JSON.parse(localStorage.getItem('customers')) || [];
-                customers.push(data);
+                if(editId){
+                    const idx=customers.findIndex(c=>c.id==editId);
+                    if(idx>-1){data.id=customers[idx].id;customers[idx]=data;}
+                }else{
+                    data.id=Date.now();
+                    customers.push(data);
+                }
+                localStorage.setItem('recentCustomer', JSON.stringify(data));
                 localStorage.setItem('customers', JSON.stringify(customers));
-                setTimeout(()=>{
-                    currentStep=4;
-                    updateSteps();
-                },500);
+
+                let employers=JSON.parse(localStorage.getItem('employers'))||[];
+                if(data.employerName){
+                    let emp=employers.find(e=>e.name.toLowerCase()==data.employerName.toLowerCase());
+                    if(!emp){
+                        emp={name:data.employerName,code:data.employerCode||generateCode(data.employerName)};
+                        employers.push(emp);
+                    }
+                    localStorage.setItem('employers',JSON.stringify(employers));
+                }
+
+                setTimeout(()=>{currentStep=4;updateSteps();},500);
             }
         });
         function addAnother(){

--- a/customers.html
+++ b/customers.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Customers</title>
+    <style>
+        body{font-family:Arial,Helvetica,sans-serif;background:linear-gradient(135deg,#667eea 0%,#764ba2 50%,#f093fb 100%);color:#fff;min-height:100vh;margin:0;padding:0;}
+        .container{max-width:1000px;margin:2rem auto;background:rgba(255,255,255,0.1);backdrop-filter:blur(20px);padding:1.5rem;border-radius:16px;}
+        h1{margin-bottom:1rem;}
+        table{width:100%;border-collapse:collapse;margin-top:1rem;}
+        th,td{padding:0.5rem;border-bottom:1px solid rgba(255,255,255,0.2);} 
+        th{background:rgba(0,0,0,0.2);}
+        input[type="text"]{padding:0.5rem;border-radius:4px;border:1px solid rgba(255,255,255,0.3);width:100%;max-width:300px;background:rgba(0,0,0,0.1);color:#fff;}
+        button{padding:0.4rem 0.8rem;margin-left:0.5rem;border:none;border-radius:4px;cursor:pointer;color:#fff;background:#667eea;}
+        .actions button{margin-right:0.25rem;background:#764ba2;}
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1>Customers</h1>
+    <div>
+        <input type="text" id="search" placeholder="Search by name, surname, ID or cell">
+        <button onclick="exportCustomers()">Export</button>
+        <button onclick="window.location.href='add-customer.html'">Add Customer</button>
+    </div>
+    <table id="customersTable">
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Surname</th>
+                <th>ID</th>
+                <th>Cell</th>
+                <th>Employer</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+</div>
+<script>
+const customers = JSON.parse(localStorage.getItem('customers')) || [];
+const loans = JSON.parse(localStorage.getItem('loans')) || [];
+const tbody = document.querySelector('#customersTable tbody');
+const searchInput = document.getElementById('search');
+function render(list){
+    tbody.innerHTML='';
+    list.forEach(c=>{
+        const tr=document.createElement('tr');
+        tr.innerHTML=`<td>${c.firstName||''}</td><td>${c.lastName||''}</td><td>${c.nationalId||''}</td><td>${c.phoneNumber||''}</td><td>${c.employerName||''}</td><td class='actions'></td>`;
+        const actions=tr.querySelector('.actions');
+        const editBtn=document.createElement('button');
+        editBtn.textContent='Edit';
+        editBtn.onclick=()=>window.location.href=`add-customer.html?id=${c.id}`;
+        const delBtn=document.createElement('button');
+        delBtn.textContent='Delete';
+        delBtn.onclick=()=>deleteCustomer(c.id);
+        actions.appendChild(editBtn);actions.appendChild(delBtn);
+        tbody.appendChild(tr);
+    });
+}
+function deleteCustomer(id){
+    const inUse = loans.some(l=>l.clientId===id);
+    if(inUse){alert('Cannot delete customer with linked transactions');return;}
+    if(confirm('Delete this customer?')){
+        let list=JSON.parse(localStorage.getItem('customers'))||[];
+        list=list.filter(c=>c.id!==id);
+        localStorage.setItem('customers',JSON.stringify(list));
+        render(list);
+    }
+}
+function exportCustomers(){
+    const data=JSON.stringify(JSON.parse(localStorage.getItem('customers'))||[]);
+    const blob=new Blob([data],{type:'application/json'});
+    const url=URL.createObjectURL(blob);
+    const a=document.createElement('a');
+    a.href=url;a.download='customers.json';a.click();URL.revokeObjectURL(url);
+}
+searchInput.addEventListener('input',()=>{
+    const q=searchInput.value.toLowerCase();
+    const filtered=customers.filter(c=>
+        (c.firstName&&c.firstName.toLowerCase().includes(q))||
+        (c.lastName&&c.lastName.toLowerCase().includes(q))||
+        (c.nationalId&&c.nationalId.includes(q))||
+        (c.phoneNumber&&c.phoneNumber.includes(q)));
+    render(filtered);
+});
+render(customers);
+</script>
+</body>
+</html>

--- a/employers.html
+++ b/employers.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Employers</title>
+    <style>
+        body{font-family:Arial,Helvetica,sans-serif;background:linear-gradient(135deg,#667eea 0%,#764ba2 50%,#f093fb 100%);color:#fff;min-height:100vh;margin:0;padding:0;}
+        .container{max-width:800px;margin:2rem auto;background:rgba(255,255,255,0.1);backdrop-filter:blur(20px);padding:1.5rem;border-radius:16px;}
+        h1{margin-bottom:1rem;}
+        table{width:100%;border-collapse:collapse;margin-top:1rem;}
+        th,td{padding:0.5rem;border-bottom:1px solid rgba(255,255,255,0.2);} 
+        th{background:rgba(0,0,0,0.2);}
+        input[type="file"]{margin-left:0.5rem;}
+        button{padding:0.4rem 0.8rem;margin-left:0.5rem;border:none;border-radius:4px;cursor:pointer;color:#fff;background:#667eea;}
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1>Employers</h1>
+    <div>
+        <button onclick="exportEmployers()">Export</button>
+        <input type="file" id="importFile" accept="application/json">
+        <button onclick="importEmployers()">Import</button>
+    </div>
+    <table id="employersTable">
+        <thead>
+            <tr><th>Name</th><th>Code</th></tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+</div>
+<script>
+function load(){
+    employers=JSON.parse(localStorage.getItem('employers'))||[];
+    const tbody=document.querySelector('#employersTable tbody');
+    tbody.innerHTML='';
+    employers.forEach(e=>{
+        const tr=document.createElement('tr');
+        tr.innerHTML=`<td>${e.name}</td><td>${e.code}</td>`;
+        tbody.appendChild(tr);
+    });
+}
+function exportEmployers(){
+    const data=JSON.stringify(JSON.parse(localStorage.getItem('employers'))||[]);
+    const blob=new Blob([data],{type:'application/json'});
+    const url=URL.createObjectURL(blob);
+    const a=document.createElement('a');a.href=url;a.download='employers.json';a.click();URL.revokeObjectURL(url);
+}
+function importEmployers(){
+    const f=document.getElementById('importFile').files[0];
+    if(!f){alert('Select a file');return;}
+    const r=new FileReader();
+    r.onload=function(){
+        try{
+            const arr=JSON.parse(r.result); if(Array.isArray(arr)){
+                let list=JSON.parse(localStorage.getItem('employers'))||[];
+                arr.forEach(e=>{ if(!list.find(x=>x.code===e.code)) list.push(e); });
+                localStorage.setItem('employers',JSON.stringify(list));
+                load();
+            }else{alert('Invalid file');}
+        }catch(e){alert('Invalid file');}
+    };
+    r.readAsText(f);
+}
+let employers=[];load();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- require employer info on customer form and auto-generate an employer code
- allow editing of customers
- keep employers in localStorage and generate codes
- add page to list/manage customers
- add page to view, export and import employers

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685937c6785c832e97b37b27a1ef9b3f