### PR TITLE
Store data in Firebase across pages

### DIFF
--- a/add-customer.html
+++ b/add-customer.html
@@ -305,7 +305,7 @@
 
     <script type="module">
         import { db } from './firebase-config.js';
-        import { collection, doc, setDoc } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-firestore.js';
+        import { collection, doc, setDoc, getDoc } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-firestore.js';
         let currentStep = 1;
         const totalSteps = 3;
 
@@ -370,8 +370,15 @@
         const urlParams=new URLSearchParams(window.location.search);
         const editId=urlParams.get('id');
         if(editId){
-            const customers=JSON.parse(localStorage.getItem('customers'))||[];
-            const customer=customers.find(c=>c.id==editId);
+            let customer=null;
+            try{
+                const snap=await getDoc(doc(collection(db,'customers'), editId));
+                if(snap.exists()) customer=snap.data();
+            }catch(err){
+                console.error('Firebase load failed', err);
+                const customers=JSON.parse(localStorage.getItem('customers'))||[];
+                customer=customers.find(c=>c.id==editId);
+            }
             if(customer){
                 Object.keys(customer).forEach(k=>{if(form.elements[k]) form.elements[k].value=customer[k];});
             }

--- a/customer-profile.html
+++ b/customer-profile.html
@@ -517,8 +517,20 @@
         </div>
     </div>
 
-    <script>
-        const customer = JSON.parse(localStorage.getItem('recentCustomer')) || {};
+    <script type="module">
+        import { db } from './firebase-config.js';
+        import { doc, getDoc, collection, getDocs } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-firestore.js';
+
+        const cached = JSON.parse(localStorage.getItem('recentCustomer')) || {};
+        let customer = cached;
+        if(cached.id){
+            try{
+                const snap = await getDoc(doc(db,'customers',cached.id.toString()));
+                if(snap.exists()) customer = snap.data();
+            }catch(err){
+                console.error('Firebase load failed', err);
+            }
+        }
         if (Object.keys(customer).length) {
             const fullName = `${customer.firstName || ''} ${customer.lastName || ''}`.trim();
             const initials = (customer.firstName ? customer.firstName[0] : 'C') + (customer.lastName ? customer.lastName[0] : 'U');
@@ -548,7 +560,15 @@
             return 'status-pending';
         }
 
-        const loans = JSON.parse(localStorage.getItem('loans')) || [];
+        let loans = [];
+        try{
+            const loanSnap = await getDocs(collection(db,'loans'));
+            loans = loanSnap.docs.map(d=>d.data());
+            localStorage.setItem('loans', JSON.stringify(loans));
+        }catch(err){
+            console.error('Firebase load failed', err);
+            loans = JSON.parse(localStorage.getItem('loans')) || [];
+        }
         const loanRows = document.getElementById('loanRows');
         if (loanRows) {
             loanRows.innerHTML = '';

--- a/customers.html
+++ b/customers.html
@@ -215,11 +215,14 @@
         <div class="pagination" id="pagination"></div>
     </div>
 
-<script>
+<script type="module">
+import { db } from './firebase-config.js';
+import { collection, getDocs, doc, setDoc, deleteDoc } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-firestore.js';
+
 const PAGE_SIZE = 10;
 
-const customers = JSON.parse(localStorage.getItem('customers')) || [];
-const loans = JSON.parse(localStorage.getItem('loans')) || [];
+let customers = [];
+let loans = [];
 const tbody = document.querySelector('#customersTable tbody');
 const customersCount = document.getElementById('customersCount');
 const statsCards = document.getElementById('statsCards');
@@ -227,12 +230,25 @@ const pagination = document.getElementById('pagination');
 let filtered = [];
 let currentPage = 1;
 
-// ensure extra properties exist
-customers.forEach(c=>{
-    if(!c.status) c.status='active';
-    if(!c.creditScore){ c.creditScore = Math.floor(620+Math.random()*130); }
-});
-localStorage.setItem('customers', JSON.stringify(customers));
+async function loadData(){
+    try{
+        const custSnap = await getDocs(collection(db,'customers'));
+        customers = custSnap.docs.map(d=>d.data());
+        const loanSnap = await getDocs(collection(db,'loans'));
+        loans = loanSnap.docs.map(d=>d.data());
+        customers.forEach(c=>{
+            if(!c.status) c.status='active';
+            if(!c.creditScore) c.creditScore=Math.floor(620+Math.random()*130);
+        });
+        localStorage.setItem('customers', JSON.stringify(customers));
+        localStorage.setItem('loans', JSON.stringify(loans));
+    }catch(err){
+        console.error('Firebase load failed', err);
+        customers = JSON.parse(localStorage.getItem('customers')) || [];
+        loans = JSON.parse(localStorage.getItem('loans')) || [];
+    }
+    applyFilters();
+}
 
 function computeStats(list){
     const total = list.length;
@@ -308,7 +324,12 @@ function deleteCustomer(id){
     const use = loans.some(l=>l.clientId==id);
     if(use){alert('Cannot delete customer with linked transactions');return;}
     const idx=customers.findIndex(c=>c.id==id);
-    if(idx>-1){customers.splice(idx,1);localStorage.setItem('customers',JSON.stringify(customers));applyFilters();}
+    if(idx>-1){
+        customers.splice(idx,1);
+        localStorage.setItem('customers',JSON.stringify(customers));
+        deleteDoc(doc(db,'customers',id.toString())).catch(console.error);
+        applyFilters();
+    }
 
 }
 
@@ -347,8 +368,14 @@ document.getElementById('reportSelected').addEventListener('click',()=>{
 
 document.getElementById('deactivateSelected').addEventListener('click',()=>{
     document.querySelectorAll('.rowCheck:checked').forEach(c=>{
-        const cust=customers.find(x=>x.id==c.dataset.id);if(cust) cust.status='inactive';});
-    localStorage.setItem('customers',JSON.stringify(customers));applyFilters();
+        const cust=customers.find(x=>x.id==c.dataset.id);
+        if(cust){
+            cust.status='inactive';
+            setDoc(doc(db,'customers',cust.id.toString()), cust).catch(console.error);
+        }
+    });
+    localStorage.setItem('customers',JSON.stringify(customers));
+    applyFilters();
 });
 
 document.getElementById('exportBtn').addEventListener('click',()=>{
@@ -360,7 +387,7 @@ const importFile=document.getElementById('importFile');
 document.getElementById('importBtn').addEventListener('click',()=>importFile.click());
 importFile.addEventListener('change',e=>{
     const file=e.target.files[0];if(!file) return;const reader=new FileReader();
-    reader.onload=ev=>{try{const data=JSON.parse(ev.target.result);if(Array.isArray(data)){data.forEach(d=>{if(!d.id) d.id=Date.now()+Math.random();customers.push(d);});localStorage.setItem('customers',JSON.stringify(customers));applyFilters();}}catch(err){alert('Invalid file');}};reader.readAsText(file);
+    reader.onload=ev=>{try{const data=JSON.parse(ev.target.result);if(Array.isArray(data)){data.forEach(async d=>{if(!d.id) d.id=Date.now()+Math.random();customers.push(d);await setDoc(doc(db,'customers',d.id.toString()),d);});localStorage.setItem('customers',JSON.stringify(customers));applyFilters();}}catch(err){alert('Invalid file');}};reader.readAsText(file);
 });
 
 document.getElementById('addBtn').addEventListener('click',()=>window.location.href='add-customer.html');
@@ -435,7 +462,7 @@ function toggleStats(){
     arrow.textContent=grid.classList.contains('expanded')?'▲':'▼';
 }
 
-applyFilters();
+loadData();
 </script>
 </body>
 </html>

--- a/employers.html
+++ b/employers.html
@@ -35,9 +35,19 @@
         <tbody></tbody>
     </table>
 </div>
-<script>
-function load(){
-    employers=JSON.parse(localStorage.getItem('employers'))||[];
+<script type="module">
+import { db } from './firebase-config.js';
+import { collection, getDocs, setDoc, doc } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-firestore.js';
+
+async function load(){
+    try{
+        const snap = await getDocs(collection(db,'employers'));
+        employers = snap.docs.map(d=>d.data());
+        localStorage.setItem('employers',JSON.stringify(employers));
+    }catch(err){
+        console.error('Firebase load failed', err);
+        employers=JSON.parse(localStorage.getItem('employers'))||[];
+    }
     const tbody=document.querySelector('#employersTable tbody');
     tbody.innerHTML='';
     employers.forEach(e=>{
@@ -60,7 +70,7 @@ function importEmployers(){
         try{
             const arr=JSON.parse(r.result); if(Array.isArray(arr)){
                 let list=JSON.parse(localStorage.getItem('employers'))||[];
-                arr.forEach(e=>{ if(!list.find(x=>x.code===e.code)) list.push(e); });
+                arr.forEach(async e=>{ if(!list.find(x=>x.code===e.code)) list.push(e); await setDoc(doc(db,'employers',e.code),e); });
                 localStorage.setItem('employers',JSON.stringify(list));
                 load();
             }else{alert('Invalid file');}

--- a/new-loan.html
+++ b/new-loan.html
@@ -93,8 +93,16 @@
     </div>
 <script type="module">
 import { db } from './firebase-config.js';
-import { collection, doc, setDoc } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-firestore.js';
-const customers = JSON.parse(localStorage.getItem('customers')) || [];
+import { collection, doc, setDoc, getDocs } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-firestore.js';
+let customers = [];
+try{
+    const snap = await getDocs(collection(db,'customers'));
+    customers = snap.docs.map(d=>d.data());
+    localStorage.setItem('customers', JSON.stringify(customers));
+}catch(err){
+    console.error('Firebase load failed', err);
+    customers = JSON.parse(localStorage.getItem('customers')) || [];
+}
 let currentStep = 1;
 let selectedCustomer = null;
 const resultsList = document.getElementById('results');


### PR DESCRIPTION
## Summary
- fetch customers from Firestore when editing
- load customers and loans from Firestore on the customers page
- sync employer changes with Firestore
- load customers list in loan application from Firestore
- pull customer and loan data from Firestore on the profile page

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68597792ef8c832e92404325d371d576