### PR TITLE
Use Firestore only and drop dummy storage

### DIFF
--- a/add-customer.html
+++ b/add-customer.html
@@ -359,6 +359,7 @@
             document.getElementById('formActions').style.display=currentStep===4?'none':'flex';
         }
         const form=document.getElementById('customerForm');
+        let savedId=null;
         const employerNameInput=document.getElementById('employerName');
         const employerCodeInput=document.getElementById('employerCode');
 
@@ -374,17 +375,14 @@
         const urlParams=new URLSearchParams(window.location.search);
         const editId=urlParams.get('id');
         if(editId){
-            let customer=null;
             try{
                 const snap=await getDoc(doc(collection(db,'customers'), editId));
-                if(snap.exists()) customer=snap.data();
+                if(snap.exists()){
+                    const customer=snap.data();
+                    Object.keys(customer).forEach(k=>{if(form.elements[k]) form.elements[k].value=customer[k];});
+                }
             }catch(err){
                 console.error('Firebase load failed', err);
-                const customers=JSON.parse(localStorage.getItem('customers'))||[];
-                customer=customers.find(c=>c.id==editId);
-            }
-            if(customer){
-                Object.keys(customer).forEach(k=>{if(form.elements[k]) form.elements[k].value=customer[k];});
             }
         }
 
@@ -393,27 +391,15 @@
             if(validateCurrentStep()){
                 const data={};
                 new FormData(form).forEach((v,k)=>data[k]=v);
-                const customers = JSON.parse(localStorage.getItem('customers')) || [];
                 if(editId){
-                    const idx=customers.findIndex(c=>c.id==editId);
-                    if(idx>-1){data.id=customers[idx].id;customers[idx]=data;}
+                    data.id = editId;
                 }else{
-                    data.id=Date.now();
-                    customers.push(data);
+                    data.id = Date.now().toString();
                 }
-                localStorage.setItem('recentCustomer', JSON.stringify(data));
-                localStorage.setItem('customers', JSON.stringify(customers));
 
-                let employers=JSON.parse(localStorage.getItem('employers'))||[];
                 let employerDoc=null;
                 if(data.employerName){
-                    let emp=employers.find(e=>e.name.toLowerCase()==data.employerName.toLowerCase());
-                    if(!emp){
-                        emp={name:data.employerName,code:data.employerCode||generateCode(data.employerName)};
-                        employers.push(emp);
-                    }
-                    employerDoc=emp;
-                    localStorage.setItem('employers',JSON.stringify(employers));
+                    employerDoc={name:data.employerName,code:data.employerCode||generateCode(data.employerName)};
                 }
 
                 try{
@@ -423,7 +409,11 @@
                     }
                 }catch(err){
                     console.error('Firebase save failed', err);
+                    alert('Failed to save customer');
+                    return;
                 }
+
+                savedId = data.id;
 
                 setTimeout(()=>{currentStep=4;updateSteps();},500);
             }
@@ -434,7 +424,9 @@
             updateSteps();
         }
         function viewCustomer(){
-            window.location.href='customer-profile.html';
+            if(savedId){
+                window.location.href = `customer-profile.html?id=${savedId}`;
+            }
         }
         updateSteps();
         window.nextStep = nextStep;

--- a/customer-profile.html
+++ b/customer-profile.html
@@ -521,11 +521,12 @@
         import { db } from './firebase-config.js';
         import { doc, getDoc, collection, getDocs } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-firestore.js';
 
-        const cached = JSON.parse(localStorage.getItem('recentCustomer')) || {};
-        let customer = cached;
-        if(cached.id){
+        const params = new URLSearchParams(window.location.search);
+        const id = params.get('id');
+        let customer = {};
+        if(id){
             try{
-                const snap = await getDoc(doc(db,'customers',cached.id.toString()));
+                const snap = await getDoc(doc(db,'customers',id));
                 if(snap.exists()) customer = snap.data();
             }catch(err){
                 console.error('Firebase load failed', err);
@@ -564,10 +565,9 @@
         try{
             const loanSnap = await getDocs(collection(db,'loans'));
             loans = loanSnap.docs.map(d=>d.data());
-            localStorage.setItem('loans', JSON.stringify(loans));
         }catch(err){
             console.error('Firebase load failed', err);
-            loans = JSON.parse(localStorage.getItem('loans')) || [];
+            loans = [];
         }
         const loanRows = document.getElementById('loanRows');
         if (loanRows) {

--- a/customers.html
+++ b/customers.html
@@ -240,12 +240,10 @@ async function loadData(){
             if(!c.status) c.status='active';
             if(!c.creditScore) c.creditScore=Math.floor(620+Math.random()*130);
         });
-        localStorage.setItem('customers', JSON.stringify(customers));
-        localStorage.setItem('loans', JSON.stringify(loans));
     }catch(err){
         console.error('Firebase load failed', err);
-        customers = JSON.parse(localStorage.getItem('customers')) || [];
-        loans = JSON.parse(localStorage.getItem('loans')) || [];
+        customers = [];
+        loans = [];
     }
     applyFilters();
 }
@@ -326,7 +324,6 @@ function deleteCustomer(id){
     const idx=customers.findIndex(c=>c.id==id);
     if(idx>-1){
         customers.splice(idx,1);
-        localStorage.setItem('customers',JSON.stringify(customers));
         deleteDoc(doc(db,'customers',id.toString())).catch(console.error);
         applyFilters();
     }
@@ -334,8 +331,7 @@ function deleteCustomer(id){
 }
 
 function viewCustomer(id){
-    const cust=customers.find(c=>c.id==id);
-    if(cust){localStorage.setItem('recentCustomer',JSON.stringify(cust));window.location.href='customer-profile.html';}
+    window.location.href = `customer-profile.html?id=${id}`;
 }
 
 function updateBulk(){
@@ -374,7 +370,6 @@ document.getElementById('deactivateSelected').addEventListener('click',()=>{
             setDoc(doc(db,'customers',cust.id.toString()), cust).catch(console.error);
         }
     });
-    localStorage.setItem('customers',JSON.stringify(customers));
     applyFilters();
 });
 
@@ -387,7 +382,7 @@ const importFile=document.getElementById('importFile');
 document.getElementById('importBtn').addEventListener('click',()=>importFile.click());
 importFile.addEventListener('change',e=>{
     const file=e.target.files[0];if(!file) return;const reader=new FileReader();
-    reader.onload=ev=>{try{const data=JSON.parse(ev.target.result);if(Array.isArray(data)){data.forEach(async d=>{if(!d.id) d.id=Date.now()+Math.random();customers.push(d);await setDoc(doc(db,'customers',d.id.toString()),d);});localStorage.setItem('customers',JSON.stringify(customers));applyFilters();}}catch(err){alert('Invalid file');}};reader.readAsText(file);
+    reader.onload=ev=>{try{const data=JSON.parse(ev.target.result);if(Array.isArray(data)){data.forEach(async d=>{if(!d.id) d.id=Date.now()+Math.random();customers.push(d);await setDoc(doc(db,'customers',d.id.toString()),d);});applyFilters();}}catch(err){alert('Invalid file');}};reader.readAsText(file);
 });
 
 document.getElementById('addBtn').addEventListener('click',()=>window.location.href='add-customer.html');

--- a/employers.html
+++ b/employers.html
@@ -43,10 +43,9 @@ async function load(){
     try{
         const snap = await getDocs(collection(db,'employers'));
         employers = snap.docs.map(d=>d.data());
-        localStorage.setItem('employers',JSON.stringify(employers));
     }catch(err){
         console.error('Firebase load failed', err);
-        employers=JSON.parse(localStorage.getItem('employers'))||[];
+        employers=[];
     }
     const tbody=document.querySelector('#employersTable tbody');
     tbody.innerHTML='';
@@ -57,7 +56,7 @@ async function load(){
     });
 }
 function exportEmployers(){
-    const data=JSON.stringify(JSON.parse(localStorage.getItem('employers'))||[]);
+    const data=JSON.stringify(employers);
     const blob=new Blob([data],{type:'application/json'});
     const url=URL.createObjectURL(blob);
     const a=document.createElement('a');a.href=url;a.download='employers.json';a.click();URL.revokeObjectURL(url);
@@ -69,9 +68,7 @@ function importEmployers(){
     r.onload=function(){
         try{
             const arr=JSON.parse(r.result); if(Array.isArray(arr)){
-                let list=JSON.parse(localStorage.getItem('employers'))||[];
-                arr.forEach(async e=>{ if(!list.find(x=>x.code===e.code)) list.push(e); await setDoc(doc(db,'employers',e.code),e); });
-                localStorage.setItem('employers',JSON.stringify(list));
+                arr.forEach(async e=>{ if(!employers.find(x=>x.code===e.code)) employers.push(e); await setDoc(doc(db,'employers',e.code),e); });
                 load();
             }else{alert('Invalid file');}
         }catch(e){alert('Invalid file');}

--- a/new-loan.html
+++ b/new-loan.html
@@ -98,10 +98,9 @@ let customers = [];
 try{
     const snap = await getDocs(collection(db,'customers'));
     customers = snap.docs.map(d=>d.data());
-    localStorage.setItem('customers', JSON.stringify(customers));
 }catch(err){
     console.error('Firebase load failed', err);
-    customers = JSON.parse(localStorage.getItem('customers')) || [];
+    customers = [];
 }
 let currentStep = 1;
 let selectedCustomer = null;
@@ -217,10 +216,6 @@ document.getElementById('loanForm').addEventListener('submit',async function(e){
         installment: parseFloat(installment.toFixed(2)),
         status:'Application'
     };
-    const loans = JSON.parse(localStorage.getItem('loans')) || [];
-    loans.push(loan);
-    localStorage.setItem('loans', JSON.stringify(loans));
-
     try{
         await setDoc(doc(collection(db,'loans'), loan.id.toString()), loan);
     }catch(err){


### PR DESCRIPTION
## Summary
- load and save customer data directly in Firestore
- read employer records from Firestore
- drop localStorage fallbacks for customers, employers, loans
- pass customer id in query string when navigating to profile pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68597b699c68832e83467f2a526a34b0