### PR TITLE
Update loan application saving

### DIFF
--- a/loan-application.html
+++ b/loan-application.html
@@ -157,7 +157,30 @@
         function goBack(){ window.history.back(); }
         function saveDraft(){ submitToFirestore('draft'); }
         async function submitApplication(){ const requiredFields=document.querySelectorAll('[required]'); let valid=true; requiredFields.forEach(f=>{ if(!f.value.trim()){ f.style.borderColor='#ef4444'; valid=false; } else { f.style.borderColor='rgba(255,255,255,0.2)'; }}); if(!valid){ alert('Please fill in all required fields'); return; } await submitToFirestore('pending'); alert('Application saved! Proceeding to next step.'); }
-        async function submitToFirestore(status){ const selectedType=document.querySelector('.loan-type-card.selected').dataset.type; const data={ id:Date.now(), type:selectedType, amount:parseFloat(document.getElementById('loanAmount').value), purpose:document.getElementById('loanPurpose').value, term:parseInt(document.getElementById('loanTerm').value), rate:parseFloat(document.getElementById('interestRate').value)||null, customer:document.getElementById('customerSelect').value, status }; const loans=JSON.parse(localStorage.getItem('loans'))||[]; loans.push(data); localStorage.setItem('loans', JSON.stringify(loans)); try{ await setDoc(doc(collection(db,'loans'), data.id.toString()), data); }catch(err){ console.error('Firebase save failed', err); } }
+        async function submitToFirestore(status){
+            const selectedType = document.querySelector('.loan-type-card.selected').dataset.type;
+            const data = {
+                id: Date.now().toString(),
+                type: selectedType,
+                amount: parseFloat(document.getElementById('loanAmount').value),
+                purpose: document.getElementById('loanPurpose').value,
+                term: parseInt(document.getElementById('loanTerm').value),
+                rate: parseFloat(document.getElementById('interestRate').value) || null,
+                customer: document.getElementById('customerSelect').value || null,
+                status,
+                createdAt: new Date().toISOString()
+            };
+
+            const loans = JSON.parse(localStorage.getItem('loans')) || [];
+            loans.push(data);
+            localStorage.setItem('loans', JSON.stringify(loans));
+
+            try{
+                await setDoc(doc(collection(db, 'loanApplications'), data.id), data);
+            }catch(err){
+                console.error('Firebase save failed', err);
+            }
+        }
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- store new loan application records in a `loanApplications` Firestore collection
- capture creation time for each application

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685982eca200832ea6df4f9b64aa21e5